### PR TITLE
Added a new request '.dbg N' to ease debugging a running roff inside a pipe.

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,18 @@
+
+This is an experimental fork of Ali Gholami Rudis neatroff-suite.
+
+Currently its only purpose is to be used as a field for
+experiments to find the a certain error when two lists
+are contained in document, which uses the mm-macros.
+
+To use neatroff always use the source provided by Ali via
+https://github.com/aligrudi/neatroff_make
+
+mcctuxic
+
+
+- original text of the README follows --------------------------------
+
 NEATROFF
 ========
 

--- a/ren.c
+++ b/ren.c
@@ -3,6 +3,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
 #include "roff.h"
 
 #define NOPAGE		0x40000000	/* undefined bp_next */
@@ -50,6 +55,15 @@ static int ren_next(void)
 static void ren_back(int c)
 {
 	ren_unbuf[ren_un++] = c;
+}
+
+void tr_dbg( char **args ) {
+    int seconds;
+	if (args[1]) {
+	    seconds = eval(args[1], '\0');
+        errmsg( "Execution will start again in %d seconds...\n", seconds );
+        sleep( seconds );
+    }
 }
 
 void tr_di(char **args)

--- a/roff.h
+++ b/roff.h
@@ -356,6 +356,7 @@ void tr_br(char **args);
 void tr_ce(char **args);
 void tr_ch(char **args);
 void tr_cl(char **args);
+void tr_dbg(char **args);
 void tr_di(char **args);
 void tr_divbeg(char **args);
 void tr_divend(char **args);

--- a/tr.c
+++ b/tr.c
@@ -1129,6 +1129,7 @@ static struct cmd {
 	{"cp", tr_cp},
 	{"cs", tr_cs},
 	{"da", tr_di},
+	{"dbg", tr_dbg},
 	{"de", tr_de, mkargs_reg1},
 	{"di", tr_di},
 	{"ds", tr_ds, mkargs_ds},


### PR DESCRIPTION
Added the request .dbg N, which can be included in macro code or
document code and halt execution of roff for N seconds to allow for
accesing the related task with a debugger. Debugging a pipe is somehow
difficult otherwise.
