### PR TITLE
draw: use \D'l'-style lines when no character is specified

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -114,8 +114,12 @@ void ren_hlcmd(struct wb *wb, char *arg)
 	int l = eval_up(&arg, 'm');
 	if (arg[0] == c_ec && arg[1] == '&')	/* \& can be used as a separator */
 		arg += 2;
-	if (!*arg || charread(&arg, lc) < 0)
+	if (!*arg || charread(&arg, lc) < 0){
 		strcpy(lc, "ru");
+		if(l)
+			wb_drawl(wb, 'l', l, 0);
+		return;
+	}
 	if (l)
 		ren_hline(wb, l, lc);
 }
@@ -126,8 +130,12 @@ void ren_vlcmd(struct wb *wb, char *arg)
 	int l = eval_up(&arg, 'v');
 	if (arg[0] == c_ec && arg[1] == '&')	/* \& can be used as a separator */
 		arg += 2;
-	if (!*arg || charread(&arg, lc) < 0)
+	if (!*arg || charread(&arg, lc) < 0){
 		strcpy(lc, "br");
+		if(l)
+			wb_drawl(wb, 'l', 0, l);
+		return;
+	}
 	if (l)
 		ren_vline(wb, l, lc);
 }


### PR DESCRIPTION
When no character is specified, neatroff draws a line using veritcal and horizontal bars. This can be problematic in some cases (fonts used, little gap that looks odd in print, etc.).

It is reasonable to assume that when a line is to be printed, it should simply be a line.

This is the same behavior as that of groff. Moreover, it is coherent with line functions (setlinewidth, setlinejoin, and setlinecap, available via \X and neatpost).

This requires matching changes in eqn and tbl.