### PR TITLE
Fix vertical relative position in \D mode

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -134,7 +134,7 @@ int eval_up(char **s, int unit)
 {
 	defunit = unit;
 	if (unit == 'v')
-		abspos = -n_d;
+		abspos = -n_d - ren_vpos();
 	if (unit == 'm')
 		abspos = n_lb - f_hpos();
 	return evalexpr(s);

--- a/ren.c
+++ b/ren.c
@@ -95,6 +95,11 @@ int f_hpos(void)
 	return fmt_wid(cfmt) + wb_wid(cwb);
 }
 
+int ren_vpos(void)
+{
+	return wb_vpos(cwb);
+}
+
 void tr_divbeg(char **args)
 {
 	odiv_beg();

--- a/roff.h
+++ b/roff.h
@@ -344,6 +344,7 @@ void ren_bcmd(struct wb *wb, char *arg);	/* \b */
 void ren_ocmd(struct wb *wb, char *arg);	/* \o */
 void ren_dcmd(struct wb *wb, char *arg);	/* \D */
 void ren_zcmd(struct wb *wb, char *arg);	/* \Z */
+int ren_vpos(void);
 
 /* out.c */
 void out_line(char *s);				/* output rendered line */


### PR DESCRIPTION
The number register \n(.d does not contain the
vertical position until wb is put into fmt. This
is problematic for drawing functions because
relative positions such as |1i are not relative to the current word buffer (in which the drawing is
done) but to fmt. This causes unexpected drawings.

This is not compliant to the behavior of either
groff, heirloom doctools, or Plan 9's troff, but
we the behavior with horizontal vertical position
is already non-compliant.

An alternative is to adopt the other troff's
behavior, that is to never update the  relative
position while parsing a drawing function.