### PR TITLE
Add \D't' from groff for line thickness

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -151,7 +151,7 @@ static int tok_numpt(char **s, int scale, int *i)
 
 void ren_dcmd(struct wb *wb, char *s)
 {
-	int h1, h2, v1, v2;
+	int h1, h2, v1, v2, w;
 	int c = *s++;
 	switch (tolower(c)) {
 	case 'l':
@@ -191,6 +191,10 @@ void ren_dcmd(struct wb *wb, char *s)
 			}
 		}
 		wb_drawxend(wb);
+		break;
+	case 't':
+		w = tok_num(&s, 'u');
+		wb_drawt(wb, c, w);
 		break;
 	}
 }

--- a/out.c
+++ b/out.c
@@ -117,6 +117,9 @@ static void out_draw(char *s)
 			}
 		}
 		break;
+	case 't':
+		outnn(" %d", tok_num(&s, 'u'));
+		break;
 	}
 	outnn("\n");
 }

--- a/roff.h
+++ b/roff.h
@@ -261,6 +261,7 @@ void wb_drawl(struct wb *wb, int c, int h, int v);
 void wb_drawc(struct wb *wb, int c, int r);
 void wb_drawe(struct wb *wb, int c, int h, int v);
 void wb_drawa(struct wb *wb, int c, int h1, int v1, int h2, int v2);
+void wb_drawt(struct wb *wb, int c, int wid);
 void wb_drawxbeg(struct wb *wb, int c);
 void wb_drawxdot(struct wb *wb, int h, int v);
 void wb_drawxcmd(struct wb *wb, char *cmd);

--- a/wb.c
+++ b/wb.c
@@ -377,6 +377,12 @@ void wb_drawa(struct wb *wb, int c, int h1, int v1, int h2, int v2)
 	wb_stsb(wb);
 }
 
+void wb_drawt(struct wb *wb, int c, int wid)
+{
+	wb_flush(wb);
+	sbuf_printf(&wb->sbuf, "%cD'%c %d'", c_ec, c, wid);
+}
+
 void wb_drawxbeg(struct wb *wb, int c)
 {
 	wb_flush(wb);


### PR DESCRIPTION
A new drawing primitive, mirroring groff's, was
introduced: \D't'. It allows directly setting line width using units. \D't 1i' has expected results
(a line width of an inch), whereas

.nr a 1i
.dv set linewidth \na

does not, because the argument of linewidth is in
thousandths of ems. It's also arguably more
cumbersome.

This requires matching changes in neatpost.