### PR TITLE
Fixed overflow warnings

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -99,7 +99,7 @@ int dev_open(char *dir, char *dev)
 			continue;
 		}
 		if (!strcmp("sizes", tok)) {
-			while (fscanf(desc, "%128s", tok) == 1)
+			while (fscanf(desc, "%127s", tok) == 1)
 				if (!strcmp("0", tok))
 					break;
 			continue;

--- a/hyph.c
+++ b/hyph.c
@@ -409,15 +409,15 @@ void hyph_done(void)
 
 void tr_hpf(char **args)
 {
-	/* reseting the patterns */
+	/* resetting the patterns */
 	hypats_len = 0;
 	hy_n = 0;
 	dict_free(hydict);
-	/* reseting the dictionary */
+	/* resetting the dictionary */
 	hwword_len = 0;
 	hw_n = 0;
 	dict_free(hwdict);
-	/* reseting hcode mappings */
+	/* resetting hcode mappings */
 	hcode_n = 0;
 	dict_free(hcodedict);
 	/* reading */

--- a/hyph.c
+++ b/hyph.c
@@ -362,14 +362,14 @@ void tr_hpfa(char **args)
 	}
 	/* reading patterns */
 	if (args[1] && (filp = fopen(args[1], "r"))) {
-		while (fscanf(filp, "%128s", tok) == 1)
+		while (fscanf(filp, "%127s", tok) == 1)
 			if (strlen(tok) < WORDLEN)
 				hy_add(tok);
 		fclose(filp);
 	}
 	/* reading exceptions */
 	if (args[2] && (filp = fopen(args[2], "r"))) {
-		while (fscanf(filp, "%128s", tok) == 1)
+		while (fscanf(filp, "%127s", tok) == 1)
 			if (strlen(tok) < WORDLEN)
 				hw_add(tok);
 		fclose(filp);
@@ -381,7 +381,7 @@ void tr_hpfa(char **args)
 			hcode_add(hycase[i][1], hycase[i][0]);
 	/* reading hcode mappings */
 	} else if (args[3] && (filp = fopen(args[3], "r"))) {
-		while (fscanf(filp, "%128s", tok) == 1) {
+		while (fscanf(filp, "%127s", tok) == 1) {
 			char *s = tok;
 			if (utf8read(&s, c1) && utf8read(&s, c2) && !*s)
 				hcode_add(c2, c1);	/* inverting */

--- a/reg.c
+++ b/reg.c
@@ -28,7 +28,7 @@ static int nregs_fmt[NREGS];	/* number register format */
 static char *sregs[NREGS];	/* global string registers */
 static void *sregs_dat[NREGS];	/* builtin function data */
 static struct env *envs[NREGS];	/* environments */
-static struct env *env;		/* current enviroment */
+static struct env *env;		/* current environment */
 static int env_id;		/* current environment id */
 static int eregs_idx[NREGS];	/* register environment index in eregs[] */
 

--- a/ren.c
+++ b/ren.c
@@ -336,7 +336,7 @@ static int ren_line(char *line, int w, int ad, int body,
 	sbuf_init(&send);
 	sbuf_init(&sbuf);
 	sbuf_append(&sbuf, line);
-	lspc = MAX(1, n_L) * n_v;	/* line space, ignoreing \x */
+	lspc = MAX(1, n_L) * n_v;	/* line space, ignoring \x */
 	prev_d = n_d;
 	if (!n_ns || line[0] || els_neg || els_pos) {
 		if (els_neg)

--- a/roff.h
+++ b/roff.h
@@ -103,7 +103,7 @@ void str_rn(int src, int dst);
 void odiv_beg(void);
 void odiv_end(void);
 
-/* enviroments */
+/* environments */
 void env_init(void);
 void env_done(void);
 struct fmt *env_fmt(void);


### PR DESCRIPTION
```
cc -c -Wall -O2 "-DTROFFFDIR=\"/neatroff/font\"" "-DTROFFMDIR=\"/neatroff/tmac\"" dev.c
dev.c:102:33: warning: 'fscanf' may overflow; destination buffer in argument 3 has size 128, but the corresponding specifier may require size 129 [-Wfortify-source]
  102 |                         while (fscanf(desc, "%128s", tok) == 1)
      |                                                      ^
1 warning generated.
